### PR TITLE
Generics improvement.

### DIFF
--- a/src/main/java/guru/springframework/spring6resttemplate/model/BeerDTOPageImpl.java
+++ b/src/main/java/guru/springframework/spring6resttemplate/model/BeerDTOPageImpl.java
@@ -13,21 +13,21 @@ import java.util.List;
  * Created by jt, Spring Framework Guru.
  */
 @JsonIgnoreProperties(ignoreUnknown = true, value = "pageable")
-public class BeerDTOPageImpl<BeerDTO> extends PageImpl<guru.springframework.spring6resttemplate.model.BeerDTO> {
+public class BeerDTOPageImpl extends PageImpl<BeerDTO> {
 
     @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
-    public BeerDTOPageImpl(@JsonProperty("content") List<guru.springframework.spring6resttemplate.model.BeerDTO> content,
+    public BeerDTOPageImpl(@JsonProperty("content") List<BeerDTO> content,
                            @JsonProperty("number") int page,
                            @JsonProperty("size") int size,
                            @JsonProperty("totalElements") long total) {
         super(content, PageRequest.of(page, size), total);
     }
 
-    public BeerDTOPageImpl(List<guru.springframework.spring6resttemplate.model.BeerDTO> content, Pageable pageable, long total) {
+    public BeerDTOPageImpl(List<BeerDTO> content, Pageable pageable, long total) {
         super(content, pageable, total);
     }
 
-    public BeerDTOPageImpl(List<guru.springframework.spring6resttemplate.model.BeerDTO> content) {
+    public BeerDTOPageImpl(List<BeerDTO> content) {
         super(content);
     }
 }


### PR DESCRIPTION
Hi John,

I'm following your Spring 6 course on Udemy, and I really like it.
Great job. I was following lesson 196 from section 19, and I think I saw an improvement regarding the BeerDTOPageImpl.
In the lesson you used the fully qualified name of the BeerDTO class to make it work.
But I believe that isn't necessary, but because of the Generic right after "public class BeerDTOPageImpl<BeerDTO", BeerDTO was seen as a Generic type identifier (or what you may call it). If you remove that one, then you can use PageImpl<BeerDTO> instead of the fully qualified name.

Kind regards,
Alexander van Vark
